### PR TITLE
 Fix for https://github.com/Droplr/aws-env/issues/13

### DIFF
--- a/aws-env.go
+++ b/aws-env.go
@@ -57,6 +57,7 @@ func PrintExportParameter(path string, parameter *ssm.Parameter) {
 
 	env := strings.Trim(name[len(path):], "/")
 	value = strings.Replace(value, "\n", "\\n", -1)
+	value = strings.Replace(value, "'", "\\'", -1)
 
 	fmt.Printf("export %s=$'%s'\n", env, value)
 }


### PR DESCRIPTION
Before:
export FOO=$''<bar>''
(leads to bash trying to load file bar)
After:
export FOO=$'\'<bar>\''
(gives the expected environment variable FOO with value 'bar' (including quotes))
