### PR TITLE
Add recursive option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,20 @@ $ export DB_USERNAME=$'Username'
 $ export DB_PASSWORD=$'SecretPassword'
 ```
 
+You can also pass the `--recursive` flag.  When specified, aws-env will recursively fetch parameters starting from the base path specified in 
+`AWS_ENV_PATH`.  For the exported environment variables, any `/` characters from sub-paths will be converted to `_` characters.  For example:
+
+With the following parameters:
+```
+$ aws ssm put-parameter --name /prod/my-app/db0/DB_PASSWORD --value "SecretPassword" --type SecureString --key-id "alias/aws/ssm0" --region us-west-2
+$ aws ssm put-parameter --name /prod/my-app/db1/DB_PASSWORD --value "OtherSecretPassword" --type SecureString --key-id "alias/aws/ssm1" --region us-west-2
+```
+
+`eval $(AWS_ENV_PATH=/prod/my-app/ AWS_REGION=us-west-2 ./aws-env --recursive)` will output:
+```
+$ export db0_DB_PASSWORD=$'SecretPassword'
+$ export db1_DB_PASSWORD=$'OtherSecretPassword'
+```
 
 ## Example Dockerfile
 


### PR DESCRIPTION
This adds the option to specify a `--recursive` flag.  If used, the parameters found will be exported as environment variables with the `/` character substituted with `_`.  Behavior without the recursive flag is unchanged.

Example:
`/parameter/key1` -> `parameter_key1`