### PR TITLE
Add optional to disable strip path and enable uppercasing the name

### DIFF
--- a/aws-env.go
+++ b/aws-env.go
@@ -16,6 +16,12 @@ const (
 	formatDotenv  = "dotenv"
 )
 
+type FormattingOpts struct {
+	Format    string
+	StripPath bool
+	Uppercase bool
+}
+
 func main() {
 	if os.Getenv("AWS_ENV_PATH") == "" {
 		log.Println("aws-env running locally, without AWS_ENV_PATH")
@@ -23,6 +29,8 @@ func main() {
 	}
 
 	recursivePtr := flag.Bool("recursive", false, "recursively process parameters on path")
+	stripPath := flag.Bool("strip-path", true, "remove the AWS_ENV_PATH from the environment variable name")
+	uppercase := flag.Bool("uppercase", false, "print the env variable in all caps")
 	format := flag.String("format", formatExports, "output format")
 	flag.Parse()
 
@@ -34,7 +42,8 @@ func main() {
 	sess := CreateSession()
 	client := CreateClient(sess)
 
-	ExportVariables(client, os.Getenv("AWS_ENV_PATH"), *recursivePtr, *format, "")
+	formattingOpts := FormattingOpts{Format: *format, StripPath: *stripPath, Uppercase: *uppercase}
+	ExportVariables(client, os.Getenv("AWS_ENV_PATH"), *recursivePtr, formattingOpts, "")
 }
 
 func CreateSession() *session.Session {
@@ -45,7 +54,7 @@ func CreateClient(sess *session.Session) *ssm.SSM {
 	return ssm.New(sess)
 }
 
-func ExportVariables(client *ssm.SSM, path string, recursive bool, format string, nextToken string) {
+func ExportVariables(client *ssm.SSM, path string, recursive bool, opts FormattingOpts, nextToken string) {
 	input := &ssm.GetParametersByPathInput{
 		Path:           &path,
 		WithDecryption: aws.Bool(true),
@@ -63,22 +72,31 @@ func ExportVariables(client *ssm.SSM, path string, recursive bool, format string
 	}
 
 	for _, element := range output.Parameters {
-		OutputParameter(path, element, format)
+		OutputParameter(path, element, opts)
 	}
 
 	if output.NextToken != nil {
-		ExportVariables(client, path, recursive, format, *output.NextToken)
+		ExportVariables(client, path, recursive, opts, *output.NextToken)
 	}
 }
 
-func OutputParameter(path string, parameter *ssm.Parameter, format string) {
+func OutputParameter(path string, parameter *ssm.Parameter, opts FormattingOpts) {
 	name := *parameter.Name
 	value := *parameter.Value
 
-	env := strings.Replace(strings.Trim(name[len(path):], "/"), "/", "_", -1)
+	if opts.StripPath {
+		name = name[len(path):]
+	}
+
+	env := strings.Replace(strings.Trim(name, "/"), "/", "_", -1)
+
+	if opts.Uppercase {
+		env = strings.ToUpper(env)
+	}
+
 	value = strings.Replace(value, "\n", "\\n", -1)
 
-	switch format {
+	switch opts.Format {
 	case formatExports:
 		fmt.Printf("export %s=$'%s'\n", env, value)
 	case formatDotenv:


### PR DESCRIPTION
This commit adds two new cli flags:
1. -strip-path Will remove the AWS_ENV_PATH from the environment
variable, useful when you need to call aws-env multiple times and want
to ensure that the environment variables exposed won't conflict with
each other.
2. -uppercase Changes the capitalisation of the variable's name to
all-caps. It is common for ssm parameters to be in all-lowercase whereas
we obviously want the environment variables to be in uppercase.