### PR TITLE
Replace all characters with underscores instead of just the slashes

### DIFF
--- a/aws-env.go
+++ b/aws-env.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"log"
 	"os"
+	"regexp"
 	"strings"
 )
 
@@ -75,7 +76,7 @@ func OutputParameter(path string, parameter *ssm.Parameter, format string) {
 	name := *parameter.Name
 	value := *parameter.Value
 
-	env := strings.Replace(strings.Trim(name[len(path):], "/"), "/", "_", -1)
+	env := regexp.MustCompile(`\W`).ReplaceAllString(strings.Trim(name[len(path):], "/"), "_")
 	value = strings.Replace(value, "\n", "\\n", -1)
 
 	switch format {


### PR DESCRIPTION
Previously aws-env would only replace slashes with underscores, but the
ssm parameters themselves can contain other characters that do not
translate well in the name of an environment variable.

This commit makes the code a bit more flexible by replacing all non-word
characters (numbers and letters) with underscores.